### PR TITLE
Add Hostbip Registry Domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12751,4 +12751,12 @@ bss.design
 // Submitted by Su Hendro <admin@zone.id>
 zone.id
 
+
+// HOSTBIP REGISTRY : https://www.hostbip.com/
+// Submitted by Atanunu Igbunuroghene <atanunuigbunu@esebun.com>
+ltd.ng
+gen.ng
+col.ng
+sch.so
+
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [] Run Syntax Checker (make test)


Description of Organization
====

Organization Website: https://hostbip.com

I am Atanunu Igbunuroghene, a representative of HostBip  - a PaaS, Hosting and Domain Names Provider - these are the domains we use / offer to our clients using our applications OR issue out to individuals or institutions interested in having a domain name under our tlds.

Reason for PSL Inclusion
====

This request is seeking to add these to the PSL so the individuals / institutions operating under these suffixes can gain access to services such as Let's Encrypt, Cloudflare and that other third party systems may better be able to identify the level at which the personal/private name has been registered.


DNS Verification via dig
=======
```
dig +short TXT _psl.ltd.ng
"https://github.com/publicsuffix/list/pull/770"
```

```
dig +short TXT _psl.col.ng
"https://github.com/publicsuffix/list/pull/770"
```

```
dig +short TXT _psl.gen.ng
"https://github.com/publicsuffix/list/pull/770"
```

```
dig +short TXT _psl.sch.so
"https://github.com/publicsuffix/list/pull/770"
```
make test
=========

Did not run the test
