### PR TITLE
UPDATE HOSTBIP DOMAIN NAMES  (2022)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12478,7 +12478,7 @@ firm.ng
 gen.ng
 ltd.ng
 ngo.ng
-edu.scot
+plc.ng
 sch.so
 
 // HostyHosting (hostyhosting.com)

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12473,12 +12473,12 @@ hoplix.shop
 // Submitted by Atanunu Igbunuroghene <publicsuffixlist@hostbip.com>
 orx.biz
 biz.gl
+biz.ng
 col.ng
 firm.ng
 gen.ng
 ltd.ng
 ngo.ng
-plc.ng
 sch.so
 
 // HostyHosting (hostyhosting.com)


### PR DESCRIPTION
* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 
  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

  * [x] This request was _not_ submitted with the objective of working around other third-party limits

  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---

Description of Organization
====
'HostBip' is a 'PDNR' (Private Domain Name Registry), allowing 3rd parties to register domain names in a variety of domain name extensions/suffixes. This pull request adds or updates the entries for a number of domain extensions that we operate, and disclaims a number of domain names we are no longer operating registry services for.

Organization Website: https://hostbip.com/

Reason for PSL Inclusion
====
'HostBip' has an existing section in the 'Public Suffix List', and is updating the section to include additional domain extensions/suffixes in its portfolio and removing edu.scot domain from the list.

This request is seeking to add these to the PSL so the individuals/institutions operating under these suffixes can gain access to services such as Let's Encrypt, Cloudflare and that other third party systems may better be able to identify the level at which the personal/private name has been registered.

Number of users this request is being made to serve: we are expecting to serve over 300 public limited liability companies in the Nigerian marketplace. 


DNS Verification via dig
=======

```
dig +short TXT _psl.biz.ng
"https://github.com/publicsuffix/list/pull/XXXX"
```
```
dig +short TXT _psl.edu.scot
"https://github.com/publicsuffix/list/pull/1130"
```

Results of Syntax Checker (`make test`)
=========

```
I've run make test, and it reports that all tests pass.
```

