### PR TITLE
Rename HOSTBIP REGISTRY to Enterprise IT Registry (Change of Metadata)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13391,6 +13391,22 @@ objects.lp.dev
 // Submitted by Marcel Daus <cloudops@encoway.de>
 eu.encoway.cloud
 
+// ENTERPRISE IT REGISTRY : https://www.enterprise.biz.ng/
+// Submitted by Atanunu Igbunuroghene <registry@it.biz.ng>
+orx.biz
+biz.ng
+co.biz.ng
+dl.biz.ng
+go.biz.ng
+lg.biz.ng
+on.biz.ng
+col.ng
+firm.ng
+gen.ng
+ltd.ng
+ngo.ng
+plc.ng
+
 // EU.org : https://eu.org/
 // Submitted by Pierre Beyssac <hostmaster@eu.org>
 eu.org
@@ -14045,22 +14061,6 @@ seprox.hooc.me
 // Hoplix : https://www.hoplix.com
 // Submitted by Danilo De Franco<info@hoplix.shop>
 hoplix.shop
-
-// HOSTBIP REGISTRY : https://www.hostbip.com/
-// Submitted by Atanunu Igbunuroghene <publicsuffixlist@hostbip.com>
-orx.biz
-biz.ng
-co.biz.ng
-dl.biz.ng
-go.biz.ng
-lg.biz.ng
-on.biz.ng
-col.ng
-firm.ng
-gen.ng
-ltd.ng
-ngo.ng
-plc.ng
 
 // HostyHosting : https://hostyhosting.com
 hostyhosting.io


### PR DESCRIPTION
## Description of Organization

Enterprise IT Registry is a private domain name registry operator that provides registry-style domain namespaces for third-party registrants.

The organization allows individuals, institutions, and businesses to register domain names under domain extensions and suffixes operated by Enterprise IT Registry. These registrants are independent parties and should be treated as separate registrable entities by systems that consume the Public Suffix List.

Enterprise IT Registry is the updated operating name for the registry section currently listed as `HOSTBIP REGISTRY` in the PRIVATE section. This pull request updates the organization name, organization website, and role-based contact address for the existing registry block.

**Organization Website:**

https://www.enterprise.biz.ng/